### PR TITLE
[feature] add section headers for each organization

### DIFF
--- a/app/components/app.android.js
+++ b/app/components/app.android.js
@@ -4,6 +4,7 @@ import {
   StyleSheet,
   Text,
   View,
+  Image,
   ToolbarAndroid,
   Button,
   StatusBar,
@@ -55,7 +56,7 @@ class App extends Component {
     }
 
     return (
-      <View style={{ flex: 1 }}>
+      <View style={{ flex: 1, backgroundColor: BACKGROUND_COLOR }}>
         { this.props.hasFetched ? this.renderStats(servers, autoqueue) : this.renderActivityIndicator() }
       </View>
     );

--- a/app/components/app.ios.js
+++ b/app/components/app.ios.js
@@ -58,7 +58,7 @@ class App extends Component {
     }
 
     return (
-      <View style={{ flex: 1 }}>
+      <View style={{ flex: 1, backgroundColor: BACKGROUND_COLOR }}>
         { this.props.hasFetched ? this.renderStats(servers, autoqueue) : this.renderActivityIndicator() }
       </View>
     );

--- a/app/components/detail/detail_content.js
+++ b/app/components/detail/detail_content.js
@@ -36,7 +36,6 @@ class DetailContent extends Component {
   }
 
   getTopic(id, organizationId) {
-    console.log(id, organizationId)
     return Platform.select({
       ios: `/topics/ios.${ENV}.${organizationId}.${id}`,
       android: `android.${ENV}.${organizationId}.${id}`

--- a/app/components/header.js
+++ b/app/components/header.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import _ from 'lodash'
+import { connect } from 'react-redux'
+
+import { getOrganizationName } from '../util/parser'
+
+class Header extends Component {
+  render() {
+    return (
+      <View style={{ height: 64, alignItems: 'flex-start', justifyContent: 'center', marginLeft: 16  }}>
+        <Text style={{ fontSize: 24, fontWeight: '500', color: '#fff' }}>{this.props.name}</Text>
+      </View>
+    )
+  }
+}
+
+function mapStateToProps(state, { organizationId }) {
+  const organization = _.get(state, ['stats', 'data', 'organizations', organizationId])
+
+  return {
+    name: getOrganizationName(organizationId, organization)
+  }
+}
+
+Header.defaultProps = {
+  organization: {},
+  organizationId: null
+}
+
+export default connect(mapStateToProps)(Header)

--- a/app/components/material/box.js
+++ b/app/components/material/box.js
@@ -51,7 +51,7 @@ class Box extends Component {
             style={{ height, width }}
             source={{ uri: this.props.imageURL }}
           />
-        <View style={[ styles.boxFooter, { width, height: footerHeight }]}>
+          <View style={[ styles.boxFooter, { width, height: footerHeight }]}>
             <View style={styles.textWrapper}>
               <Text
                 ellipsizeMode='tail'

--- a/app/util/parser.js
+++ b/app/util/parser.js
@@ -34,7 +34,7 @@ export function parseRealmData(id, { servers = {}, available } = {}) {
 }
 
 export function getOrganizationName(id, organization = {}) {
-  return organization.name
+  return organization.name || 'Unknown Organization'
 }
 
 export function getTitle(id, server = {}) {
@@ -68,6 +68,7 @@ export function parseStatus(server, autoqueue, realmdata) {
   const image = getImage(id, server)
   const order = getOrder(id, server)
   const dontGroup = getDontGroup(id, server)
+  const organizationId = getOrganizationId(id, server)
 
   let subtitle
   if (!isService) {
@@ -80,6 +81,7 @@ export function parseStatus(server, autoqueue, realmdata) {
     status,
     image,
     id,
+    organizationId,
     isService,
     order,
     dontGroup


### PR DESCRIPTION
# Work Done
1. [refactor] simplify grid logic
2. [feature] add dynamic headers (Organization Name grouping)
3. [future feature] Lay ground work for maxWidth Landscape content

# Pictures
**Organization Headers**
<img src="https://user-images.githubusercontent.com/5419727/32428286-fcd06c1e-c292-11e7-99eb-c70b0c3639c7.png" height=400 />

<img src="https://user-images.githubusercontent.com/5419727/32428302-10ab26a2-c293-11e7-853d-73952789a7fd.png" height=400 />


